### PR TITLE
Fix for [BUG] max() iterable argument is empty #677 (#683)

### DIFF
--- a/streamrip/client/downloadable.py
+++ b/streamrip/client/downloadable.py
@@ -124,9 +124,14 @@ class DeezerDownloadable(Downloadable):
         self.session = session
         self.url = info["url"]
         self.source: str = "deezer"
-        max_quality_available = max(
+        qualities_available = [
             i for i, size in enumerate(info["quality_to_size"]) if size > 0
-        )
+        ]
+        if len(qualities_available) == 0:
+            raise NonStreamableError(
+                "Missing download info. Skipping.",
+            )
+        max_quality_available = max(qualities_available)
         self.quality = min(info["quality"], max_quality_available)
         self._size = info["quality_to_size"][self.quality]
         if self.quality <= 1:

--- a/streamrip/media/playlist.py
+++ b/streamrip/media/playlist.py
@@ -79,7 +79,7 @@ class PendingPlaylistTrack(Pending):
                 self.client.get_downloadable(self.id, quality),
             )
         except NonStreamableError as e:
-            logger.error("Error fetching download info for track: %s", e)
+            logger.error(f"Error fetching download info for track {self.id}: {e}")
             self.db.set_failed(self.client.source, "track", self.id)
             return None
 


### PR DESCRIPTION
* seems to work - halt progress if this info is missing

* Minor fixes

---------